### PR TITLE
generate Java 8 bytecode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,8 +25,10 @@ subprojects {
         }
     }
 
-    configure<JavaPluginExtension> {
-        targetCompatibility = JavaVersion.VERSION_1_8
+    afterEvaluate {
+        this.configure<JavaPluginExtension> {
+            targetCompatibility = JavaVersion.VERSION_1_8
+        }
     }
 
     group = "com.dailymotion.kinta"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,10 @@ subprojects {
         }
     }
 
+    configure<JavaPluginExtension> {
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     group = "com.dailymotion.kinta"
     version = "0.1.1-SNAPSHOT"
 

--- a/kinta-cli/src/main/resources/build.gradle.kts
+++ b/kinta-cli/src/main/resources/build.gradle.kts
@@ -13,6 +13,10 @@ repositories {
     }
 }
 
+configure<JavaPluginExtension> {
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     api("com.dailymotion.kinta:kinta-lib:0.1.0")
     // The builtin workflows are in [com.dailymotion.kinta.BuiltinWorkflows].


### PR DESCRIPTION
This makes sure that the bytecode generated does not depend on the JVM installed on the machine that generated it.