### PR TITLE
Add kinta env

### DIFF
--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/EnvProperties.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/EnvProperties.kt
@@ -4,14 +4,16 @@ import java.io.File
 import java.util.*
 
 object EnvProperties {
+    const val filename = "env.properties"
+
     private val properties = Properties()
     private val file by lazy {
         val projectDir = Project.findBaseDir()
 
         if (projectDir != null) {
-            File(projectDir, ".kinta/env.properties")
+            File(projectDir, ".kinta/$filename")
         } else {
-            File(".kinta/env.properties")
+            File(".kinta/$filename")
         }
     }
 

--- a/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/BuiltInWorkflows.kt
+++ b/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/BuiltInWorkflows.kt
@@ -7,6 +7,7 @@ import com.dailymotion.kinta.integration.gitlab.GitlabIntegration
 import com.dailymotion.kinta.integration.gitlab.internal.GitlabInit
 import com.dailymotion.kinta.integration.googleplay.internal.GooglePlayIntegration
 import com.dailymotion.kinta.workflows.builtin.actions.actions
+import com.dailymotion.kinta.workflows.builtin.env.envCommand
 import com.dailymotion.kinta.workflows.builtin.playstore.PlayStoreInit
 import com.dailymotion.kinta.workflows.builtin.gittool.*
 import com.dailymotion.kinta.workflows.builtin.playstore.*
@@ -67,7 +68,8 @@ object BuiltInWorkflows {
                     gitHubWorkflows,
                     gitlabWorkflows,
                     Travis,
-                    actions
+                    actions,
+                    envCommand
             )
 }
 

--- a/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/builtin/actions/Actions.kt
+++ b/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/builtin/actions/Actions.kt
@@ -87,7 +87,7 @@ object DeleteSecret : CliktCommand(name = "deleteSecret", help = "deletes a secr
 }
 
 
-val actions = object : CliktCommand(name = "actions") {
+val actions = object : CliktCommand(name = "actions", help = "Helper methods for Github Actions") {
     override fun run() {
 
     }

--- a/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/builtin/env/Env.kt
+++ b/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/builtin/env/Env.kt
@@ -42,7 +42,7 @@ private fun definedVars(filename: String?): List<Pair<String, String>> {
 
 private val toShell = object : CliktCommand(name = "toShell", help = "export the current Kinta env to a shell script that you can source later on") {
     val output by argument()
-    private val fromProperties by option()
+    private val from by option(help = "use this properties file instead of the current environment")
 
     private fun String.escape(): String {
         // this is very rudimentary and should certainly be improved
@@ -52,7 +52,7 @@ private val toShell = object : CliktCommand(name = "toShell", help = "export the
     }
 
     override fun run() {
-        definedVars(fromProperties).map {
+        definedVars(from).map {
             "${it.first}=${it.second.escape()}"
         }.joinToString(separator = "\n", postfix = "\n")
                 .let {
@@ -63,11 +63,11 @@ private val toShell = object : CliktCommand(name = "toShell", help = "export the
 
 private val toProperties = object : CliktCommand(name = "toProperties", help = "export the current Kinta env to a properties file") {
     val output by argument()
-    private val fromProperties by option()
+    private val from by option(help = "use this properties file instead of the current environment")
 
     override fun run() {
         val properties = Properties()
-        properties.putAll(definedVars(fromProperties))
+        properties.putAll(definedVars(from))
 
         File(output).bufferedWriter().use {
             properties.store(it, "")
@@ -76,9 +76,9 @@ private val toProperties = object : CliktCommand(name = "toProperties", help = "
 }
 
 private val toGithub = object : CliktCommand(name = "toGithub", help = "export the current Kinta env to github secrets") {
-    private val fromProperties by option()
+    private val from by option(help = "use this properties file instead of the current environment")
     override fun run() {
-        definedVars(fromProperties).forEach {
+        definedVars(from).forEach {
             GithubIntegration.setSecret(name = it.first, value = it.second)
         }
     }

--- a/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/builtin/env/Env.kt
+++ b/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/builtin/env/Env.kt
@@ -1,0 +1,95 @@
+package com.dailymotion.kinta.workflows.builtin.env
+
+import com.dailymotion.kinta.EnvProperties
+import com.dailymotion.kinta.KintaEnv
+import com.dailymotion.kinta.integration.github.GithubIntegration
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.option
+import java.io.File
+import java.util.*
+
+private val set = object : CliktCommand(name = "set", help = "add a variable to your ${EnvProperties.filename} file") {
+    val key by argument()
+    val value by argument()
+
+    override fun run() {
+        KintaEnv.put(key, value)
+        println("set $key=$value in ${EnvProperties.filename}")
+    }
+}
+
+private fun definedVars(filename: String?): List<Pair<String, String>> {
+    return if (filename != null) {
+        Properties().apply {
+            File(filename).bufferedReader().use {
+                load(it)
+            }
+        }.entries
+                .map { it.key as String to it.value as String}
+    } else {
+        KintaEnv.Var.values().mapNotNull {
+            val value = KintaEnv.get(it)
+            if (value != null) {
+                it.name to value
+            } else {
+                null
+            }
+        }
+    }
+}
+
+private val toShell = object : CliktCommand(name = "toShell", help = "export the current Kinta env to a shell script that you can source later on") {
+    val output by argument()
+    private val fromProperties by option()
+
+    private fun String.escape(): String {
+        // this is very rudimentary and should certainly be improved
+        return this.replace(" ", "\\ ")
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+    }
+
+    override fun run() {
+        definedVars(fromProperties).map {
+            "${it.first}=${it.second.escape()}"
+        }.joinToString(separator = "\n", postfix = "\n")
+                .let {
+                    File(output).writeText(it)
+                }
+    }
+}
+
+private val toProperties = object : CliktCommand(name = "export the current Kinta env to a properties file") {
+    val output by argument()
+    private val fromProperties by option()
+
+    override fun run() {
+        val properties = Properties()
+        properties.putAll(definedVars(fromProperties))
+
+        File(output).bufferedWriter().use {
+            properties.store(it, "")
+        }
+    }
+}
+
+private val toGithub = object : CliktCommand(name = "toGithub", help = "export the current Kinta env to github secrets") {
+    private val fromProperties by option()
+    override fun run() {
+        definedVars(fromProperties).forEach {
+            GithubIntegration.setSecret(name = it.first, value = it.second)
+        }
+    }
+}
+val envCommand = object : CliktCommand(name = "env", help = "Set/export kinta environment variables") {
+    override fun run() {
+
+    }
+}.subcommands(set,
+        toShell,
+        toProperties,
+        toGithub
+)
+

--- a/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/builtin/env/Env.kt
+++ b/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/builtin/env/Env.kt
@@ -61,7 +61,7 @@ private val toShell = object : CliktCommand(name = "toShell", help = "export the
     }
 }
 
-private val toProperties = object : CliktCommand(name = "export the current Kinta env to a properties file") {
+private val toProperties = object : CliktCommand(name = "toProperties", help = "export the current Kinta env to a properties file") {
     val output by argument()
     private val fromProperties by option()
 


### PR DESCRIPTION
Add kinta env to manipulate the environment:

```
Usage: kinta env [OPTIONS] COMMAND [ARGS]...

  Set/export kinta environment variables

Options:
  -h, --help  Show this message and exit

Commands:
  set                              add a variable to your env.properties file
  toShell                          export the current Kinta env to a shell
                                   script that you can source later on
  export the current Kinta env to a properties file
  toGithub                         export the current Kinta env to github
                                   secrets
```
