### PR TITLE
Allow clean local without a clientId

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    kotlin("jvm").version("1.3.61")
+    kotlin("jvm").version("1.3.72")
 }
 
 repositories {

--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/GitTool.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/GitTool.kt
@@ -14,6 +14,7 @@ interface GitTool {
             token: String? = null,
             owner: String? = null,
             repo: String? = null,
+            remote: String = "origin",
             branch: String): BranchInfo
 
     fun openPullRequest(token: String? = null,

--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/GitTool.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/GitTool.kt
@@ -30,6 +30,4 @@ interface GitTool {
             repo: String? = null,
             ref: String
     )
-
-    fun isConfigured(): Boolean
 }

--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/Project.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/Project.kt
@@ -3,12 +3,12 @@ package com.dailymotion.kinta
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import java.io.File
-import kotlin.system.exitProcess
 
 object Project {
 
     val repository by lazy {
-        FileRepositoryBuilder().setGitDir(file(".git"))
+        val root = findParentContaining(".git")
+        FileRepositoryBuilder().setGitDir(File(root, ".git"))
                 .readEnvironment()
                 .findGitDir()
                 .build()!!
@@ -21,8 +21,6 @@ object Project {
 
     fun file(path: String): File = File(projectDir, path)
 
-    private fun isBaseDir(dir: File) = dir.list().contains(".kinta")
-
     fun getBaseDir(): File {
         val dir = findBaseDir()
         check(dir != null) {
@@ -31,16 +29,20 @@ object Project {
         return dir
     }
 
-    fun findBaseDir(): File? {
+    fun findParentContaining(dirName: String): File? {
         var dir = File(".")
 
-        while (!isBaseDir(dir)) {
+        while (true) {
+            if (dir.listFiles().find { it.isDirectory && it.name == dirName } != null) {
+                return dir
+            }
             if (dir.parent == null) {
                 return null
             }
             dir = File(dir.parent)
         }
-
-        return dir
+    }
+    fun findBaseDir(): File? {
+        return findParentContaining(".kinta")
     }
 }

--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/git/GitIntegration.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/git/GitIntegration.kt
@@ -81,7 +81,9 @@ object GitIntegration {
         val git = Git(Project.repository)
 
         return git.branchList().call()
-                .map { it.name.substring("refs/heads/".length) }
+                .map {
+                    it.name.substring("refs/heads/".length)
+                }
     }
 
     fun deleteBranches(branches: List<String>, force: Boolean = false) {

--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/github/GithubIntegration.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/github/GithubIntegration.kt
@@ -182,7 +182,7 @@ object GithubIntegration : GitTool {
             .addInterceptor { chain ->
                 chain.proceed(chain.request()
                     .newBuilder()
-                    .addHeader("Authorization", "Bearer ${token}")
+                    .addHeader("Authorization", "Bearer $token")
                     .build()
                 )
             }
@@ -244,10 +244,10 @@ object GithubIntegration : GitTool {
 
         val request = Request.Builder()
             .post(RequestBody.create(MediaType.parse("application/json"), JsonObject(input).toString()))
-            .url("https://api.github.com/repos/$owner/$repo/releases?access_token=${token}")
+            .url("https://api.github.com/repos/$owner/$repo/releases")
             .build()
 
-        val response = OkHttpClient().newCall(request).execute()
+        val response = httpClient(token).newCall(request).execute()
         if (!response.isSuccessful) {
             throw Exception("cannot create github release: ${response.body()?.string()}")
         }
@@ -264,10 +264,10 @@ object GithubIntegration : GitTool {
 
             val request2 = Request.Builder()
                 .post(RequestBody.create(MediaType.parse("application/zip"), asset))
-                .url("$uploadUrl&access_token=$token")
+                .url(uploadUrl)
                 .build()
 
-            val response2 = OkHttpClient().newCall(request2).execute()
+            val response2 = httpClient(token).newCall(request2).execute()
             check(response2.isSuccessful) {
                 "cannot upload asset: ${response2.body()?.string()}"
             }

--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/github/GithubIntegration.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/github/GithubIntegration.kt
@@ -86,10 +86,11 @@ object GithubIntegration : GitTool {
         token: String?,
         owner: String?,
         repo: String?,
+        remote: String,
         branch: String): BranchInfo {
         val token_ = token ?: retrieveToken()
-        val owner_ = owner ?: repository().owner
-        val repo_ = repo ?: repository().name
+        val owner_ = owner ?: repository(remote).owner
+        val repo_ = repo ?: repository(remote).name
 
         val depdendentPullRequestsData = runBlocking {
             val query = GetPullRequestWithBase(owner_, repo_, branch)
@@ -194,7 +195,7 @@ object GithubIntegration : GitTool {
 
     data class Repository(val owner: String, val name: String)
 
-    fun repository(): Repository {
+    fun repository(remote: String = "origin"): Repository {
         val git = Git(Project.repository)
 
         /*
@@ -203,7 +204,7 @@ object GithubIntegration : GitTool {
          */
         val remoteConfigList = git.remoteList().call()
 
-        val uri = remoteConfigList.filter { it.name == "origin" }.first().urIs[0]
+        val uri = remoteConfigList.filter { it.name == remote }.first().urIs[0]
 
         return repoDetails(uri)
     }

--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/github/GithubIntegration.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/github/GithubIntegration.kt
@@ -144,8 +144,6 @@ object GithubIntegration : GitTool {
 
     }
 
-    override fun isConfigured() = GithubOauthClient.isConfigured()
-
     override fun getAllBranches(
         token: String?,
         owner: String?,

--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/github/internal/GithubOauthClient.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/github/internal/GithubOauthClient.kt
@@ -46,8 +46,6 @@ object GithubOauthClient {
         GithubCredentials(username!!, token!!)
     }
 
-    fun isConfigured() = !clientId.isBlank() && !clientSecret.isBlank()
-
     private fun acquireToken(): String {
         val state = randomString(16)
         val url = "https://github.com/login/oauth/authorize?client_id=$clientId&scope=repo&state=$state"

--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/gitlab/GitlabIntegration.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/gitlab/GitlabIntegration.kt
@@ -92,6 +92,7 @@ object GitlabIntegration : GitTool {
             token: String?,
             owner: String?,
             repo: String?,
+            remote: String,
             branch: String): BranchInfo {
         val token_ = token ?: retrieveToken()
         val owner_ = owner ?: repository().owner
@@ -143,7 +144,7 @@ object GitlabIntegration : GitTool {
             throw Exception(response.body()?.string() ?: "")
         }
     }
-    
+
     override fun getAllBranches(
             token: String?,
             owner: String?,

--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/gitlab/GitlabIntegration.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/gitlab/GitlabIntegration.kt
@@ -143,15 +143,7 @@ object GitlabIntegration : GitTool {
             throw Exception(response.body()?.string() ?: "")
         }
     }
-
-    override fun isConfigured() =
-            try {
-                retrieveToken()
-                true
-            } catch (e: Exception) {
-                false
-            }
-
+    
     override fun getAllBranches(
             token: String?,
             owner: String?,

--- a/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/BuiltInWorkflows.kt
+++ b/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/BuiltInWorkflows.kt
@@ -36,10 +36,6 @@ object BuiltInWorkflows {
 
     val gitHubWorkflows = object : CliktCommand(name = "github", help = "Manage your Github pull requests.") {
         override fun run() {
-            if (context.invokedSubcommand != GithubInit && !GithubIntegration.isConfigured()) {
-                println("Your environment is not set up. Please run kinta $commandName ${GithubInit.commandName}")
-                exitProcess(0)
-            }
         }
     }.subcommands(listOf(
             GithubInit,
@@ -50,10 +46,6 @@ object BuiltInWorkflows {
 
     val gitlabWorkflows = object : CliktCommand(name = "gitlab", help = "Manage your Gitlab pull requests.") {
         override fun run() {
-            if (context.invokedSubcommand != GitlabInit && !GitlabIntegration.isConfigured()) {
-                println("Your environment is not set up. Please run kinta $commandName ${GitlabInit.commandName}")
-                exitProcess(0)
-            }
         }
     }.subcommands(listOf(
             GitlabInit,

--- a/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/builtin/actions/Actions.kt
+++ b/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/builtin/actions/Actions.kt
@@ -67,11 +67,15 @@ object RetrieveKeystore : CliktCommand(name = "retrieveKeystore", help = "retrie
 object SetSecret : CliktCommand(name = "setSecret", help = "adds a secret") {
     val secretName by option().required()
     val value by option().required()
+    val owner by option()
+    val repo by option()
 
     override fun run() {
         GithubIntegration.setSecret(
             name = secretName,
-            value = value
+            value = value,
+            owner = owner,
+            repo = repo
         )
     }
 }

--- a/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/builtin/gittool/GitToolCleanLocal.kt
+++ b/kinta-workflows/src/main/kotlin/com/dailymotion/kinta/workflows/builtin/gittool/GitToolCleanLocal.kt
@@ -6,6 +6,9 @@ import com.dailymotion.kinta.integration.git.GitIntegration
 import com.dailymotion.kinta.integration.github.GithubIntegration
 import com.dailymotion.kinta.integration.gitlab.GitlabIntegration
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
 
 object GithubCleanLocal : GitCleanLocal(GithubIntegration)
 object GitlabCleanLocal : GitCleanLocal(GitlabIntegration)
@@ -18,36 +21,51 @@ open class GitCleanLocal(val gitTool: GitTool) : CliktCommand(name = "cleanLocal
     but that process is a bit more involved so double check before you call this workflow.
     This only works for repositories hosted on github.
 """.trimIndent()) {
+    val remote by option().default("origin")
+    val all by option().flag()
+
     override fun run() {
-        GitIntegration.fetch(prune = true)
+        GitIntegration.fetch(remote = remote, prune = true)
         Logger.i("Fetching branchs infos, Please wait...")
         val branchesInfo = GitIntegration.getBranches()
                 .filter { it != "master" }
-                .map { gitTool.getBranchInfo(branch = it) }
+                .map {
+                    gitTool.getBranchInfo(
+                        branch = it,
+                        remote = remote)
+                }
 
-        val branchesToDelete = branchesInfo.filter {
+        val (branchesToDelete, branchesToKeep) = branchesInfo.partition {
+            if (all) {
+                return@partition true
+            }
             if (it.pullRequests.isNullOrEmpty()) {
                 // This ref has no associated pull request yet, don't delete it
-                return@filter false
+                return@partition false
             }
 
             if (it.pullRequests.count { !it.merged && !it.closed } > 0) {
                 // There is one open pull request on this ref, don't delete it
-                return@filter false
+                return@partition false
             }
 
             if (it.dependentPullRequests.count { !it.merged && !it.closed } > 0) {
                 // This ref is used as a base for another one, don't delete it
-                return@filter false
+                return@partition false
             }
 
             // fallthrough, delete this branch
             true
-        }.map {
-            it.name
         }
+
         Logger.i("Deleting ${branchesToDelete.count()} local branchs...")
-        GitIntegration.deleteBranches(branchesToDelete, force = true)
+        GitIntegration.deleteBranches(branchesToDelete.map { it.name }, force = true)
+        branchesToDelete.forEach {
+            Logger.i("Deleted ${it.name}")
+        }
+        branchesToKeep.forEach {
+            Logger.i("Kept    ${it.name}")
+        }
         Logger.i("Clean local done!")
     }
 }


### PR DESCRIPTION
Having a GITHUB_TOKEN variable in the KintaEnv is now enough to call `cleanLocal`.

Also added the `--all
` flag to cleanLocal to delete all local branches