### PR TITLE
GooglePlayIntegration : do not set 'inappupdatePriority' to 0 if no params has been given

### DIFF
--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/googleplay/internal/GooglePlayIntegration.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/googleplay/internal/GooglePlayIntegration.kt
@@ -164,7 +164,7 @@ object GooglePlayIntegration {
             track: GooglePlayTrack,
             releaseName: String? = null,
             percent: Double = 100.0,
-            updatePriority: Int = 0) {
+            updatePriority: Int? = null) {
         val packageName_ = packageName ?: KintaEnv.getOrFail(KintaEnv.Var.GOOGLE_PLAY_PACKAGE_NAME)
 
         val publisher = publisher(googlePlayJson, packageName_)
@@ -172,7 +172,7 @@ object GooglePlayIntegration {
             val release = TrackRelease().apply {
                 name = releaseName ?: listVersionCodes.max().toString()
                 versionCodes = listVersionCodes
-                inAppUpdatePriority = updatePriority
+                updatePriority?.let { inAppUpdatePriority = it }
                 if (percent == 100.0) {
                     status = "completed"
                 } else {


### PR DESCRIPTION
The use case is : 
- You start releasing to x percent of users, setting an `updatePriority`
- if you raise the rollout later, you will be forced to pass again the `updatePriority`, else it will be reset to 0