### PR TITLE
Update appgallery release workflow

### DIFF
--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/appgallery/AppGalleryIntegration.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/appgallery/AppGalleryIntegration.kt
@@ -206,8 +206,10 @@ object AppGalleryIntegration {
                 files = listOf(com.dailymotion.kinta.integration.appgallery.internal.AppInfoFilesBody.AppFileInfo(fileName, fileUrl))
         )).execute()
 
-        val error = result.body()?.ret ?: result.errorBody()?.string() ?: result.code()
-        throw IllegalStateException("Error updating app : $error")
+        if(result.body()?.isSuccess() ?: false == false) {
+            val error = result.body()?.ret ?: result.errorBody()?.string() ?: result.code()
+            throw IllegalStateException("Error updating app : $error")
+        }
     }
 
     private fun getAppId(
@@ -269,7 +271,7 @@ object AppGalleryIntegration {
         ).execute()
 
         result.body()?.result?.uploadFileRsp?.fileInfoList?.let {
-            return it[0].disposableURL
+            return it[0].fileDestUlr
         }
         throw IllegalStateException("Error uploading to AppGallery")
     }

--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/appgallery/internal/Model.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/appgallery/internal/Model.kt
@@ -54,7 +54,7 @@ class UploadFileResult(val result: UploadResult) {
         @Serializable
         class UploadFileRsp(val fileInfoList: List<FileInfo>?) {
             @Serializable
-            class FileInfo(val disposableURL: String)
+            class FileInfo(val fileDestUlr: String)
         }
     }
 }

--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/googleplay/internal/GooglePlayIntegration.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/googleplay/internal/GooglePlayIntegration.kt
@@ -376,7 +376,6 @@ object GooglePlayIntegration {
         IMAGETYPE_FEATURE("featureGraphic"),
         IMAGETYPE_ICON("icon"),
         IMAGETYPE_PHONE("phoneScreenshots"),
-        IMAGETYPE_PROMO("promoGraphic"),
         IMAGETYPE_SEVENINCH("sevenInchScreenshots"),
         IMAGETYPE_TENINCH("tenInchScreenshots"),
         IMAGETYPE_TVBANNER("tvBanner"),


### PR DESCRIPTION
The Huawei API seems to have changed a bit :

- fileDestUlr is the key we need to updateFileInfo after a successful upload