### PR TITLE
Jira integration : Use accountId instead of userName

### DIFF
--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/KintaEnv.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/KintaEnv.kt
@@ -23,6 +23,7 @@ object KintaEnv {
         JIRA_PASSWORD,
         BITRISE_PERSONAL_TOKEN,
         JIRA_URL,
+        JIRA_ACCOUNT_ID,
         APPLE_PASSWORD,
         APPLE_USERNAME,
         KINTA_KEYSTORE,

--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/jira/internal/Model.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/jira/internal/Model.kt
@@ -25,6 +25,6 @@ data class TransitionBody(val transition: Transition)
 @Serializable
 data class TransitionResult(val transitions: List<Transition>)
 @Serializable
-data class AssignBody(val name: String)
+data class AssignBody(val accountId: String)
 @Serializable
 data class CommentBody(val body: String)


### PR DESCRIPTION
Using Jira `name` is deprecated in GDPR countries mode
It's replaced by `accountId`, something that could be found by visiting the JIRA user profile page : https://********.atlassian.net/people/[accountId] ;) 