### PR TITLE
Update kinta src build gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ tasks.withType<org.jetbrains.dokka.gradle.DokkaMultiModuleTask> {
 subprojects {
     repositories {
         mavenCentral()
-        maven ("https://repo.gradle.org/gradle/libs-releases-local/")
+        maven ("https://repo.gradle.org/gradle/libs-releases/")
     }
 
     tasks.withType<KotlinCompile> {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -30,7 +30,7 @@ object Libs {
     const val retrofit = "com.squareup.retrofit2:retrofit:2.4.0"
     const val retrofitConverter = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0"
 
-    const val gradle = "org.gradle:gradle-tooling-api:6.0.1"
+    const val gradle = "org.gradle:gradle-tooling-api:7.5.1"
 
     const val clikt = "com.github.ajalt:clikt:2.4.0"
     const val lazySodium = "com.goterl:lazysodium-java:5.0.1"

--- a/kinta-cli/src/main/kotlin/com/dailymotion/kinta/command/Init.kt
+++ b/kinta-cli/src/main/kotlin/com/dailymotion/kinta/command/Init.kt
@@ -7,6 +7,7 @@ import com.dailymotion.kinta.workflows.builtin.playstore.PlayStoreInit
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
+import org.eclipse.jgit.errors.NoWorkTreeException
 import java.io.File
 
 object Init : CliktCommand(name = "init", help = "Initialize a project.") {
@@ -61,7 +62,12 @@ object Init : CliktCommand(name = "init", help = "Initialize a project.") {
         copyResource("gitignore", "kintaSrc/.gitignore")
 
         Gradle(File("kintaSrc")).executeTask("assemble")
-        GitIntegration.add(File("kintaSrc").path)
+        try {
+            GitIntegration.add(File("kintaSrc").path)
+        } catch (e: NoWorkTreeException) {
+            /** No work tree, it's fine **/
+        }
+
 
         println("This project is now setup to use kinta. You can define your workflows in kintaSrc/src/main/.... It is meant to be in source control. Take a look around. :)")
     }

--- a/kinta-cli/src/main/resources/build.gradle.kts
+++ b/kinta-cli/src/main/resources/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.jetbrains.kotlin.jvm").version("1.3.61")
+    id("org.jetbrains.kotlin.jvm").version("1.5.10")
 }
 
 repositories {
@@ -21,13 +21,13 @@ dependencies {
 }
 
 tasks.withType<Jar> {
-
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     archiveFileName.set("kinta-workflows-custom.jar")
     from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) }) {
         /**
          * we remove INDEX.LIST else java does not find the MainClass
          * since we remove INDEX.LIST, it also looks like we need to remove signatures too. Not 100% sure why
          */
-        exclude("META-INF/*.RSA", "META-INF/*.SF", "META-INF/*.DSA", "META-INF/INDEX.LIST", "META-INF/*.kotlin_module")
+        exclude("META-INF/*.RSA", "META-INF/*.SF", "META-INF/*.DSA", "META-INF/INDEX.LIST", "META-INF/*.kotlin_module", "META-INF/versions/9/module-info.class")
     }
 }


### PR DESCRIPTION
- Use latest Gradle version 7.5.1
- Update the Kotlin version in the build.gradle resource (the one that is used when initializing the kintaSrc folder, to match what is set up in kinta (1.5.10)
- Ensure the kinta init works well in a basic sample project