### PR TITLE
Increase Android Publisher API timeout

### DIFF
--- a/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/googleplay/internal/GooglePlayIntegration.kt
+++ b/kinta-lib/src/main/kotlin/com/dailymotion/kinta/integration/googleplay/internal/GooglePlayIntegration.kt
@@ -65,8 +65,8 @@ object GooglePlayIntegration {
 
         return AndroidPublisher.Builder(HTTP_TRANSPORT, JSON_FACTORY, HttpRequestInitializer {
             it.apply {
-                connectTimeout = 100_000
-                readTimeout = 100_000
+                connectTimeout = 180_000
+                readTimeout = 180_000
             }
             credential.initialize(it)
         })


### PR DESCRIPTION
Increase the connect and read timeouts for the Android Publisher API client to 3mins